### PR TITLE
プロジェクトごとに通知先チャットルームを切り替える

### DIFF
--- a/app/views/settings/_chatwork_notifications.html.erb
+++ b/app/views/settings/_chatwork_notifications.html.erb
@@ -1,19 +1,23 @@
 <%
   client = ChatworkNotifications::Chatwork.new ChatworkNotifications::Helpers.options[:api_token]
   rooms = client.rooms rescue {}
+
+  projects = Project.all
 %>
 
 <div class="chatwork_notifications">
   <fieldset>
     <legend><%= l("chatwork.settings") %></legend>
-    <p>
-    <label for="settings_room_id"><%= l("chatwork.room") %></label>
-    <% if rooms.blank? %>
-      <span style="color: red;font-weight: bold;"><%= l("chatwork.invalid_token") %></span>
-    <% else %>
-      <%= select_tag 'settings[room_id]', options_for_select({nil => l("chatwork.label_room")}.merge(rooms).invert, @settings['room_id']) %>
-    <% end %>
-    </p>
+      <% projects.each do |prj| %>
+        <p>
+          <% if rooms.blank? %>
+            <span style="color: red;font-weight: bold;"><%= l("chatwork.invalid_token") %></span>
+          <% else %>
+            <label for="settings_room_id_#{prj.id}"><%= prj.name %></label>
+            <%= select_tag "settings[room_id][#{prj.id}]", options_for_select({nil => l("chatwork.label_room")}.merge(rooms).invert, @settings['room_id'][prj.id.to_s]) %>
+          <% end %>
+        </p>
+      <% end %>
   </fieldset>
 
   <fieldset>

--- a/app/views/settings/_chatwork_notifications.html.erb
+++ b/app/views/settings/_chatwork_notifications.html.erb
@@ -14,7 +14,7 @@
             <span style="color: red;font-weight: bold;"><%= l("chatwork.invalid_token") %></span>
           <% else %>
             <label for="settings_room_id_#{prj.id}"><%= prj.name %></label>
-            <%= select_tag "settings[room_id][#{prj.id}]", options_for_select({nil => l("chatwork.label_room")}.merge(rooms).invert, @settings['room_id'][prj.id.to_s]) %>
+            <%= select_tag "settings[room_id][#{prj.id}]", options_for_select({nil => l("chatwork.label_room")}.merge(rooms).invert, @settings['room_id'].present? ? @settings['room_id'][prj.id.to_s] : '') %>
           <% end %>
         </p>
       <% end %>

--- a/app/views/settings/_chatwork_notifications.html.erb
+++ b/app/views/settings/_chatwork_notifications.html.erb
@@ -2,7 +2,7 @@
   client = ChatworkNotifications::Chatwork.new ChatworkNotifications::Helpers.options[:api_token]
   rooms = client.rooms rescue {}
 
-  projects = Project.all
+  projects = Project.where('status =1')
 %>
 
 <div class="chatwork_notifications">

--- a/lib/chatwork_notifications/helpers.rb
+++ b/lib/chatwork_notifications/helpers.rb
@@ -32,8 +32,7 @@ module ChatworkNotifications
       end
 
       # put message to chatwork
-      def put_chatwork_message message
-        room_id = Setting.plugin_redmine_chatwork_notifications[:room_id]
+      def put_chatwork_message room_id, message
         client = ChatworkNotifications::Chatwork.new options[:api_token]
         client.put_message room_id, message
 

--- a/lib/chatwork_notifications/issue_patch.rb
+++ b/lib/chatwork_notifications/issue_patch.rb
@@ -18,7 +18,8 @@ module ChatworkNotifications
         title = l("chatwork.issue_created_notify_title", id: self.id, url: url, title: self.subject, user: self.author.name)
         description = l("chatwork.issue_created_notify_description", comment: description) if description
 
-        Helpers.put_chatwork_message [title, description.presence].compact.join("\n#{"-"*40}\n")
+        project_id = Setting.plugin_redmine_chatwork_notifications[:room_id][self.project_id.to_s]
+        Helpers.put_chatwork_message project_id, [title, description.presence].compact.join("\n#{"-"*40}\n") unless project_id.empty?
       end
     end
   end

--- a/lib/chatwork_notifications/journal_patch.rb
+++ b/lib/chatwork_notifications/journal_patch.rb
@@ -18,7 +18,8 @@ module ChatworkNotifications
         title = l("chatwork.issue_updated_notify_title", id: self.issue.id, url: url, title: self.issue.subject, user: self.user.name)
         description = l("chatwork.issue_updated_notify_description", comment: notes) if notes
 
-        Helpers.put_chatwork_message [title, description.presence].compact.join("\n#{"-"*40}\n")
+        project_id = Setting.plugin_redmine_chatwork_notifications[:room_id][self.issue.project_id.to_s]
+        Helpers.put_chatwork_message project_id, [title, description.presence].compact.join("\n#{"-"*40}\n") unless project_id.empty?
       end
     end 
   end

--- a/lib/chatwork_notifications/wiki_content_patch.rb
+++ b/lib/chatwork_notifications/wiki_content_patch.rb
@@ -20,7 +20,8 @@ module ChatworkNotifications
         title = l("chatwork.wiki_created_notify_title", url: url, project: page.project.name, title: page.pretty_title, user: self.author.name)
         description = l("chatwork.wiki_created_notify_description", comment: comment) if comment
 
-        Helpers.put_chatwork_message [title, description].compact.join("\n")
+        project_id = Setting.plugin_redmine_chatwork_notifications[:room_id][page.project.id.to_s]
+        Helpers.put_chatwork_message project_id, [title, description].compact.join("\n") unless project_id.empty?
       end
     end
 
@@ -33,7 +34,8 @@ module ChatworkNotifications
         title = l("chatwork.wiki_updated_notify_title", url: url, project: page.project.name, title: page.pretty_title, user: self.author.name)
         description = l("chatwork.wiki_updated_notify_description", comment: comment) if comment
 
-        Helpers.put_chatwork_message [title, description].compact.join("\n")
+        project_id = Setting.plugin_redmine_chatwork_notifications[:room_id][page.project.id.to_s]
+        Helpers.put_chatwork_message project_id, [title, description].compact.join("\n") unless project_id.empty?
       end
     end
   end


### PR DESCRIPTION
設定画面で、プロジェクトごとに通知先を設定できるようにしました。
プロジェクトの表示順に改良の余地があるかもしれませんが、現段階で運用可能だと思われるため、一旦PRします。

refs #3 
